### PR TITLE
Use i64 instead of i32 internally

### DIFF
--- a/lib/github.com/diku-dk/fft/stockham-radix-2.fut
+++ b/lib/github.com/diku-dk/fft/stockham-radix-2.fut
@@ -15,35 +15,34 @@ module mk_fft (R: real): {
   type real = R.t
   type complex = complex.complex
 
-  def radix:i32 = 2
+  def radix = 2i64
 
-  def fft_iteration [n] (forward: R.t) (ns: i32) (data: [n]complex) (j: i32)
+  def fft_iteration [n] (forward: R.t) (ns: i64) (data: [n]complex) (j: i64)
                   : (i64, complex, i64, complex) =
-    let angle = R.(f64(-2.0) * forward * pi) R.* (R.i32(j % ns)) R./ R.i32(ns * radix)
+    let angle = R.(f64(-2.0) * forward * pi) R.* (R.i64 (j % ns)) R./ R.i64 (ns * radix)
     let (v0, v1) = (data[j],
-                    data[j+i32.i64 n/radix] complex.* (complex.mk (R.cos angle) (R.sin angle)))
+                    data[j + n / radix] complex.* (complex.mk (R.cos angle) (R.sin angle)))
 
     let (v0, v1) =  (v0 complex.+ v1, v0 complex.- v1)
-    let idxD = ((j/ns)*ns*radix) + (j % ns)
-    in (i64.i32 idxD, v0, i64.i32 (idxD+ns), v1)
+    let idxD = ((j / ns) * ns * radix) + (j % ns)
+    in (idxD, v0, idxD + ns, v1)
 
-  def fft' [n] (forward: R.t) (input: [n]complex) (bits: i32) : [n]complex =
-    let bits64 = i64.i32 bits
+  def fft' [n] (forward: R.t) (input: [n]complex) (bits: i64) : [n]complex =
     let input = copy input
     let output = copy input
-    let ix = iota(n/i64.i32 radix)
-    let NS = map (radix**) (map i32.i64 (iota bits64))
+    let ix = iota (n / radix)
+    let NS = map (radix **) (iota bits)
     let (res,_) =
       loop (input': *[n]complex, output': *[n]complex) = (input, output) for ns in NS do
         let (i0s, v0s, i1s, v1s) =
-          unzip4 (map (fft_iteration forward ns input') (map i32.i64 ix))
+          unzip4 (map (fft_iteration forward ns input') ix)
         in (scatter output'
-                    (i0s ++ i1s :> [n]i64)
+                    (concat_to n i0s i1s)
                     (v0s ++ v1s :> [n]complex),
             input')
     in res
 
-  def log2 (n: i64) : i32 =
+  def log2 (n: i64) : i64 =
     let r = 0
     let (r, _) = loop (r,n) while 1 < n do
       let n = n / 2
@@ -56,7 +55,7 @@ module mk_fft (R: real): {
   def generic_fft [n] (forward: bool) (data: [n](R.t, R.t)): [n](R.t, R.t) =
     assert (is_power_of_2 n)
            (let bits = log2 n
-            let forward' = if forward then R.i32 1 else R.i32 (-1)
+            let forward' = if forward then R.i64 1 else R.i64 (-1)
             in fft' forward' data bits)
 
   def fft [n] (data: [n](R.t, R.t)): [n](R.t, R.t) =
@@ -76,7 +75,7 @@ module mk_fft (R: real): {
     assert (is_power_of_2 n && is_power_of_2 m)
            (let n_bits = log2 n
             let m_bits = log2 m
-            let forward' = if forward then R.i32 1 else R.i32 (-1)
+            let forward' = if forward then R.i64 1 else R.i64 (-1)
             let data = map (\r -> fft' forward' r m_bits) data
             let data = map (\c -> fft' forward' c n_bits) (transpose data)
             in transpose data)

--- a/lib/github.com/diku-dk/fft/stockham-radix-2_tests.fut
+++ b/lib/github.com/diku-dk/fft/stockham-radix-2_tests.fut
@@ -11,6 +11,10 @@ module fft = mk_fft f32
 -- output { [10f32, -2f32, -2f32, -2f32] [0f32, 2f32, 0f32, -2f32] }
 -- input { [1f32, 2f32, 3f32] [0f32, 0f32, 0f32] }
 -- error: power_of_2
+-- compiled random input { [65536]f32 [65536]f32 }
+-- compiled random input { [1048576]f32 [1048576]f32 }
+-- compiled random input { [4194304]f32 [4194304]f32 }
+-- compiled random input { [33554432]f32 [33554432]f32 }
 entry test_fft (res: []f32) (ims: []f32) = unzip (fft.fft (zip res ims))
 
 -- ==


### PR DESCRIPTION
This change simplifies the code and results in significant performance improvements on A100:

```
stockham-radix-2_tests.fut:test_fft
  #0 ("[1.0f32, 2.0f32, 3.0f32, 4.0f32] [0.0f32, 0.0f32, ..."):         1.65x
  [1048576]f32 [1048576]f32:                                            4.59x
  [33554432]f32 [33554432]f32:                                          1.26x
  [4194304]f32 [4194304]f32:                                            3.09x
  [65536]f32 [65536]f32:                                                3.85x

stockham-radix-2_tests.fut:test_fft2
  #0 ("[[1.0f32, 2.0f32], [3.0f32, 4.0f32]] [[0.0f32, 0.0..."):         1.81x (mem: 0.98x@device)

stockham-radix-2_tests.fut:test_ifft
  #0 ("[10.0f32, -2.0f32, -2.0f32, -2.0f32] [0.0f32, 2.0f..."):         2.32x

stockham-radix-2_tests.fut:test_ifft2
  #0 ("[[10.0f32, -2.0f32], [-4.0f32, 0.0f32]] [[0.0f32, ..."):         1.83x (mem: 0.98x@device)
```